### PR TITLE
Fix xv6 build on modern GCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ TOOLPREFIX := $(shell if i386-jos-elf-objdump -i 2>&1 | grep '^elf32-i386$$' >/d
 endif
 
 # If the makefile can't find QEMU, specify its path here
-#QEMU = 
+QEMU = qemu-system-i386
 QEMU_WIN = "C:/Home/ProgramFiles/qemu/qemu.exe"
 
 # Try to infer the correct QEMU
@@ -153,7 +153,7 @@ _forktest: forktest.o $(ULIB)
 	$(OBJDUMP) -S _forktest > forktest.asm
 
 mkfs: mkfs.c fs.h
-	gcc -m32 -Werror -Wall -o mkfs mkfs.c
+	gcc -Werror -Wall -O2 -o mkfs mkfs.c
 
 UPROGS=\
 	_cat\

--- a/console.c
+++ b/console.c
@@ -51,7 +51,7 @@ printint(int xx, int base, int sign)
 void
 cprintf(char *fmt, ...)
 {
-  int i, c, state, locking;
+  int i, c, locking;
   uint *argp;
   char *s;
 
@@ -60,7 +60,6 @@ cprintf(char *fmt, ...)
     acquire(&cons.lock);
 
   argp = (uint*)(void*)(&fmt + 1);
-  state = 0;
   for(i = 0; (c = fmt[i] & 0xff) != 0; i++){
     if(c != '%'){
       consputc(c);

--- a/lapic.c
+++ b/lapic.c
@@ -137,16 +137,20 @@ void
 lapicstartap(uchar apicid, uint addr)
 {
   int i;
-  ushort *wrv;
+  void *wrv;
   
   // "The BSP must initialize CMOS shutdown code to 0AH
   // and the warm reset vector (DWORD based at 40:67) to point at
   // the AP startup code prior to the [universal startup algorithm]."
   outb(IO_RTC, 0xF);  // offset 0xF is shutdown code
   outb(IO_RTC+1, 0x0A);
-  wrv = (ushort*)(0x40<<4 | 0x67);  // Warm reset vector
-  wrv[0] = 0;
-  wrv[1] = addr >> 4;
+  // Address of BIOS warm reset vector
+  wrv = (void *)(uint)(0x40<<4 | 0x67);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+  *(volatile ushort *)wrv = 0;
+  *(((volatile ushort *)wrv) + 1) = addr >> 4;
+#pragma GCC diagnostic pop
 
   // "Universal startup algorithm."
   // Send INIT (level-triggered) interrupt to reset other CPU.

--- a/mkfs.c
+++ b/mkfs.c
@@ -129,6 +129,7 @@ main(int argc, char *argv[])
     bzero(&de, sizeof(de));
     de.inum = xshort(inum);
     strncpy(de.name, argv[i], DIRSIZ);
+    de.name[DIRSIZ-1] = '\0';
     iappend(rootino, &de, sizeof(de));
 
     while((cc = read(fd, buf, sizeof(buf))) > 0)

--- a/mp.c
+++ b/mp.c
@@ -59,6 +59,8 @@ mpsearch(void)
   struct mp *mp;
 
   bda = (uchar*)0x400;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
   if((p = ((bda[0x0F]<<8)|bda[0x0E]) << 4)){
     if((mp = mpsearch1((uchar*)p, 1024)))
       return mp;
@@ -67,6 +69,7 @@ mpsearch(void)
     if((mp = mpsearch1((uchar*)p-1024, 1024)))
       return mp;
   }
+#pragma GCC diagnostic pop
   return mpsearch1((uchar*)0xF0000, 0x10000);
 }
 

--- a/sh.c
+++ b/sh.c
@@ -53,8 +53,10 @@ int fork1(void);  // Fork but panics on failure.
 void panic(char*);
 struct cmd *parsecmd(char*);
 
+static void runcmd(struct cmd *cmd) __attribute__((noreturn));
+
 // Execute cmd.  Never returns.
-void
+static void
 runcmd(struct cmd *cmd)
 {
   int p[2];

--- a/usertests.c
+++ b/usertests.c
@@ -1440,9 +1440,7 @@ bsstest(void)
 void
 bigargtest(void)
 {
-  int pid, ppid;
-
-  ppid = getpid();
+  int pid;
   pid = fork();
   if(pid == 0){
     char *args[32+1];


### PR DESCRIPTION
## Summary
- compile mkfs as 64-bit host tool and run natively
- remove disabled warning flags
- silence array-bound warnings for BIOS memory access
- mark `runcmd` as `noreturn` and fix unused vars
- ensure directory entries are null-terminated
- clean up usertests unused variable

## Testing
- `make clean`
- `make`

------
https://chatgpt.com/codex/tasks/task_e_686db07141188331bfbfd01b2420558d