### PR TITLE
Cleanup build warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,9 @@ initcode.out
 tags
 cscope.*
 *.pyc
+# Build directories
+build*/
+builds/
+*/CMakeFiles/
 
 

--- a/Makefile
+++ b/Makefile
@@ -76,9 +76,15 @@ OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
 CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb -m32 -Werror
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
+# Ensure all assembly sources emit the .note.GNU-stack section
+CFLAGS += -Wa,--noexecstack
 ASFLAGS = -m32 -gdwarf-2
 # FreeBSD ld wants ``elf_i386_fbsd''
 LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null)
+# Produce binaries that do not require an executable stack
+LDFLAGS += -z noexecstack
+# Silence linker warnings about RWX segments produced when using -N
+LDFLAGS += --no-warn-rwx-segments
 
 .PHONY: all
 all: xv6.img fs.img

--- a/PROJECT_STATUS.md
+++ b/PROJECT_STATUS.md
@@ -1,0 +1,8 @@
+## Repository Cleanup
+
+- Added `.note.GNU-stack` to all assembly sources to avoid linker warnings and
+  enforce non-executable stacks.
+- Updated `Makefile` to pass `-Wa,--noexecstack` and `-z noexecstack`.
+- Linker warnings for RWX segments silenced via --no-warn-rwx-segments.
+- Added patterns for build artifacts to `.gitignore`.
+- No build directories were present at cleanup time.

--- a/bootasm.S
+++ b/bootasm.S
@@ -87,3 +87,6 @@ gdt:
 gdtdesc:
   .word   (gdtdesc - gdt - 1)             # sizeof(gdt) - 1
   .long   gdt                             # address gdt
+
+# Mark this object file as not requiring an executable stack.
+.section .note.GNU-stack,"",@progbits

--- a/bootother.S
+++ b/bootother.S
@@ -74,3 +74,6 @@ gdt:
 gdtdesc:
   .word   (gdtdesc - gdt - 1)
   .long   gdt
+
+# Mark this object file as not requiring an executable stack.
+.section .note.GNU-stack,"",@progbits

--- a/data.S
+++ b/data.S
@@ -25,3 +25,6 @@
 data:
   .word 1
 
+# Mark this object file as not requiring an executable stack.
+.section .note.GNU-stack,"",@progbits
+

--- a/initcode.S
+++ b/initcode.S
@@ -28,3 +28,6 @@ argv:
   .long init
   .long 0
 
+# Mark this object file as not requiring an executable stack.
+.section .note.GNU-stack,"",@progbits
+

--- a/multiboot.S
+++ b/multiboot.S
@@ -73,3 +73,6 @@ gdtdesc:
   .long   gdt                             # address gdt
 
 .comm stack, STACK
+
+# Mark this object file as not requiring an executable stack.
+.section .note.GNU-stack,"",@progbits

--- a/swtch.S
+++ b/swtch.S
@@ -26,3 +26,6 @@ swtch:
   popl %ebx
   popl %ebp
   ret
+
+# Mark this object file as not requiring an executable stack.
+.section .note.GNU-stack,"",@progbits

--- a/trapasm.S
+++ b/trapasm.S
@@ -35,3 +35,6 @@ trapret:
   popl %ds
   addl $0x8, %esp  # trapno and errcode
   iret
+
+# Mark this object file as not requiring an executable stack.
+.section .note.GNU-stack,"",@progbits

--- a/usys.S
+++ b/usys.S
@@ -31,3 +31,6 @@ SYSCALL(sleep)
 SYSCALL(uptime)
 SYSCALL(ioctl)
 
+# Mark this object file as not requiring an executable stack.
+.section .note.GNU-stack,"",@progbits
+

--- a/vectors.pl
+++ b/vectors.pl
@@ -26,6 +26,9 @@ for(my $i = 0; $i < 256; $i++){
     print "  .long vector$i\n";
 }
 
+# Ensure the resulting assembly marks that it does not require an executable stack.
+print "\n.section .note.GNU-stack,\"\",\@progbits\n";
+
 # sample output:
 #   # handlers
 #   .globl alltraps


### PR DESCRIPTION
## Summary
- silence linker RWX warnings and pass `-z noexecstack`
- ensure assembler emits `.note.GNU-stack`
- ignore build directories in `.gitignore`
- document repository cleanup actions

## Testing
- `make -s`
- `make clean`

------
https://chatgpt.com/codex/tasks/task_e_688a8f3d77b88331b98179daadd20873