### PR TITLE
Fix execstack warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 &
 ASFLAGS = -m32 -gdwarf-2
 # FreeBSD ld wants ``elf_i386_fbsd''
 LDFLAGS += -m $(shell $(LD) -V | grep elf_i386 2>/dev/null)
+LDFLAGS += -z noexecstack --no-warn-rwx-segments
 
 .PHONY: all
 all: xv6.img fs.img

--- a/bootasm.S
+++ b/bootasm.S
@@ -87,3 +87,6 @@ gdt:
 gdtdesc:
   .word   (gdtdesc - gdt - 1)             # sizeof(gdt) - 1
   .long   gdt                             # address gdt
+
+# Mark the stack as non-executable
+.section .note.GNU-stack,"",@progbits

--- a/bootother.S
+++ b/bootother.S
@@ -74,3 +74,6 @@ gdt:
 gdtdesc:
   .word   (gdtdesc - gdt - 1)
   .long   gdt
+
+# Mark the stack as non-executable
+.section .note.GNU-stack,"",@progbits

--- a/data.S
+++ b/data.S
@@ -25,3 +25,6 @@
 data:
   .word 1
 
+# Mark the stack as non-executable
+.section .note.GNU-stack,"",@progbits
+

--- a/initcode.S
+++ b/initcode.S
@@ -28,3 +28,6 @@ argv:
   .long init
   .long 0
 
+# Mark the stack as non-executable
+.section .note.GNU-stack,"",@progbits
+

--- a/multiboot.S
+++ b/multiboot.S
@@ -73,3 +73,6 @@ gdtdesc:
   .long   gdt                             # address gdt
 
 .comm stack, STACK
+
+# Mark the stack as non-executable
+.section .note.GNU-stack,"",@progbits

--- a/swtch.S
+++ b/swtch.S
@@ -26,3 +26,6 @@ swtch:
   popl %ebx
   popl %ebp
   ret
+
+# Mark the stack as non-executable
+.section .note.GNU-stack,"",@progbits

--- a/trapasm.S
+++ b/trapasm.S
@@ -35,3 +35,6 @@ trapret:
   popl %ds
   addl $0x8, %esp  # trapno and errcode
   iret
+
+# Mark the stack as non-executable
+.section .note.GNU-stack,"",@progbits

--- a/usys.S
+++ b/usys.S
@@ -31,3 +31,6 @@ SYSCALL(sleep)
 SYSCALL(uptime)
 SYSCALL(ioctl)
 
+# Mark the stack as non-executable
+.section .note.GNU-stack,"",@progbits
+

--- a/vectors.pl
+++ b/vectors.pl
@@ -26,6 +26,9 @@ for(my $i = 0; $i < 256; $i++){
     print "  .long vector$i\n";
 }
 
+# Ensure a non-executable stack by emitting the GNU-stack note
+print ".section .note.GNU-stack,\"\",\@progbits\n";
+
 # sample output:
 #   # handlers
 #   .globl alltraps


### PR DESCRIPTION
## Summary
- mark assembly files with .note.GNU-stack to avoid execstack warnings
- suppress RWX segment warnings and require a non‑executable stack via linker flags

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_688a8f3d77b88331b98179daadd20873