### PR TITLE
Clarify Ethernet ioctl support

### DIFF
--- a/eth/eth.c
+++ b/eth/eth.c
@@ -15,7 +15,8 @@ ethintr()
   return;
 }
 
-// not used because ioctl() isn't still implemented.
+// Handle Ethernet-specific ioctl() requests.
+// At present only ETH_IPC_SETUP is recognized, which remains unimplemented.
 int
 ethioctl(struct inode* ip, int request, void* p)
 {

--- a/eth/eth.h
+++ b/eth/eth.h
@@ -1,6 +1,12 @@
 
-// IPCをセットアップする。IPCの仕様次第なので、実装はまだできない。
-#define ETH_IPC_SETUP     1
+/*
+ * ioctl request codes understood by ethioctl().
+ *
+ * ETH_IPC_SETUP
+ *   Prepare the device for forthcoming inter-process communication. The
+ *   feature is a placeholder until an IPC mechanism is available.
+ */
+#define ETH_IPC_SETUP 1
 
 
 


### PR DESCRIPTION
## Summary
- Clarify that `ethioctl` processes Ethernet-specific ioctl requests
- Document ioctl request codes like `ETH_IPC_SETUP`

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6892eb13da688331a25678ba42c03adb