### PR TITLE
Enable extra pedantic warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,9 @@ AS = $(TOOLPREFIX)gas
 LD = $(TOOLPREFIX)ld
 OBJCOPY = $(TOOLPREFIX)objcopy
 OBJDUMP = $(TOOLPREFIX)objdump
-CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb -m32 -Werror
+# Enforce rigorous compilation by enabling comprehensive warnings for
+# potential undefined behavior and strict ISO compliance.
+CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -Wextra -pedantic -MD -ggdb -m32 -Werror
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 # Ensure all assembly sources emit the .note.GNU-stack section
 CFLAGS += -Wa,--noexecstack

--- a/console.c
+++ b/console.c
@@ -221,7 +221,9 @@ consoleintr(int (*getc)(void))
 int
 consoleread(struct inode *ip, char *dst, int n)
 {
-  uint target;
+  // Track the desired byte count using the same signedness as `n`
+  // to prevent sign-comparison mismatches under heightened warnings.
+  int target;
   int c;
 
   iunlock(ip);

--- a/eth/eth.c
+++ b/eth/eth.c
@@ -19,6 +19,8 @@ ethintr()
 int
 ethioctl(struct inode* ip, int request, void* p)
 {
+  (void)ip;  // Unused in current implementation
+  (void)p;
   switch (request) {
   case ETH_IPC_SETUP:
     cprintf("%s: ETH_IPC_SETUP isn't still implemented because of no IPC\n", ne.name);
@@ -30,12 +32,14 @@ ethioctl(struct inode* ip, int request, void* p)
 int
 ethread(struct inode* ip, char* p, int n)
 {
+  (void)ip;  // Unused
   return ne_pio_read(&ne, (uchar*)p, n);
 }
 
 int
 ethwrite(struct inode* ip, char* p, int n)
 {
+  (void)ip;  // Unused
   return ne_pio_write(&ne, (uchar*)p, n);
 }
 
@@ -50,7 +54,7 @@ ethinit()
   devsw[ETHERNET].read = ethread;
   devsw[ETHERNET].ioctl = ethioctl;
 
-  for (i = 0; i < NELEM(ports); ++i) {
+  for (i = 0; (uint)i < NELEM(ports); ++i) {
     cprintf("Ethernet: Initialize port %d.\n", i);
     memset(&ne, 0, sizeof(ne));
     name[3] = '0' + i;

--- a/eth/ne.c
+++ b/eth/ne.c
@@ -99,7 +99,7 @@ ne_probe(ne_t* ne)
       // ループバックモードなのでlocal receive DMAはまだ動いてない。
       { DP_CR, (CR_PS_P0 | CR_DM_RR | CR_STA) },
     };
-    for (i = 0; i < NELEM(seq); ++i)
+    for (i = 0; (uint)i < NELEM(seq); ++i)
       outb(ne->base + seq[i].offset, seq[i].value);
     // 8ビットのNIC(NE1000?)かどうかもチェック
     ne->is16bit = TRUE;
@@ -209,7 +209,7 @@ ne_init(ne_t* ne)
       // (設定できるようにしたほうが良いのか？)
       { DP_RCR, RCR_PRO },
     };
-    for (i = 0; i < NELEM(seq); ++i)
+    for (i = 0; (uint)i < NELEM(seq); ++i)
       outb(ne->base + seq[i].offset, seq[i].value);
   }
 
@@ -334,7 +334,7 @@ ne_pio_read(ne_t* ne, uchar* buf, int bufsize)
   page = bnry + 1;
   
   // 末尾だったら先頭に。
-  if (page == ne->recv_stoppage)
+  if (page == (uint)ne->recv_stoppage)
     page = ne->recv_startpage;
 
   // CURRに追いついた＝パケットがない（CURRはstoppageになることがあるのか？）
@@ -361,12 +361,12 @@ ne_pio_read(ne_t* ne, uchar* buf, int bufsize)
     return -1;
   }
 
-  if (buf == 0 || pktsize > bufsize) {
+  if (buf == 0 || pktsize > (uint)bufsize) {
     return pktsize;
   } else {
     // データ読み込み。末尾から先頭に折り返しもチェックする。
-    int remain = (ne->recv_stoppage - page) * DP_PAGESIZE;
-    if (remain < pktsize) {
+    int remain = (ne->recv_stoppage - (int)page) * DP_PAGESIZE;
+    if ((uint)remain < pktsize) {
       ne_getblock(ne, page * DP_PAGESIZE + sizeof(header), remain, buf);
       ne_getblock(ne, ne->recv_startpage * DP_PAGESIZE, pktsize - remain, buf);
     } else {
@@ -377,7 +377,8 @@ ne_pio_read(ne_t* ne, uchar* buf, int bufsize)
   // 次のパケットの1ページ前にBNRYを進める
   bnry = header.next - 1;
   outb(ne->base + DP_BNRY,
-       bnry < ne->recv_startpage ? ne->recv_stoppage-1 : bnry);
+       bnry < (uint)ne->recv_startpage ?
+       (uint)(ne->recv_stoppage - 1) : bnry);
 
   return pktsize;
 }

--- a/ethtest.c
+++ b/ethtest.c
@@ -16,37 +16,37 @@ getip(int fd)
 {
   // DHCPパケットを作成し、IPアドレスを取得
   static eth_hdr_t ethhdr = {
-    dst: { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
-    src: { MAC_ADDRESS },
-    length: HTONS(ETH_TYPE_IP4),
+    .dst = { 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF },
+    .src = { MAC_ADDRESS },
+    .length = HTONS(ETH_TYPE_IP4),
   };
   static ip4_hdr_t iphdr = {
-    ver_ihl: 0x45,
-    tos: 0,
-    length: 0, // calc later
-    id: 0,
-    flag_fo: 0,
-    ttl: 0xFF,
-    protocol: IP_PROTOCOL_UDP,
-    checksum: 0,
-    src: { 0x00, 0x00, 0x00, 0x00 }, // none
-    dst: { 0xFF, 0xFF, 0xFF, 0xFF }, // broadcast
+    .ver_ihl = 0x45,
+    .tos = 0,
+    .length = 0, // calc later
+    .id = 0,
+    .flag_fo = 0,
+    .ttl = 0xFF,
+    .protocol = IP_PROTOCOL_UDP,
+    .checksum = 0,
+    .src = { 0x00, 0x00, 0x00, 0x00 }, // none
+    .dst = { 0xFF, 0xFF, 0xFF, 0xFF }, // broadcast
   };
   static udp_hdr_t udphdr = {
-    src: HTONS(UDP_PORT_BOOTPC),
-    dst: HTONS(UDP_PORT_BOOTPS),
-    length: 0, // calc later
-    checksum: 0,
+    .src = HTONS(UDP_PORT_BOOTPC),
+    .dst = HTONS(UDP_PORT_BOOTPS),
+    .length = 0, // calc later
+    .checksum = 0,
   };
   static dhcp_t dhcp = {
-    op: DHCP_OP_BOOTREQUEST,
-    htype: DHCP_HTYPE_ETH,
-    hlen: DHCP_HLEN_ETH,
-    xid: 0,
-    flags: DHCP_FLAGS_BCAST,
-    chaddr: { MAC_ADDRESS },
-    magic: HTONL(DHCP_MAGIC),
-    options: {
+    .op = DHCP_OP_BOOTREQUEST,
+    .htype = DHCP_HTYPE_ETH,
+    .hlen = DHCP_HLEN_ETH,
+    .xid = 0,
+    .flags = DHCP_FLAGS_BCAST,
+    .chaddr = { MAC_ADDRESS },
+    .magic = HTONL(DHCP_MAGIC),
+    .options = {
       DHCP_TAG_TYPE, 1, DHCP_DISCOVER,
       DHCP_TAG_CLIENTID, 7, 1, MAC_ADDRESS,
       0xFF, // stopper
@@ -104,6 +104,8 @@ ethtest(int fd)
 int
 main(int argc, char** argv)
 {
+  (void)argc;
+  (void)argv;
   int fd = open("eth", O_RDWR);
   if (fd < 0) {
     printf(1, "open: cannot open %s\n", "eth");

--- a/exec.c
+++ b/exec.c
@@ -23,7 +23,8 @@ exec(char *path, char **argv)
   pgdir = 0;
 
   // Check ELF header
-  if(readi(ip, (char*)&elf, 0, sizeof(elf)) < sizeof(elf))
+  // Ensure the full ELF header is read; cast to avoid signed/unsigned comparison.
+  if(readi(ip, (char*)&elf, 0, sizeof(elf)) < (int)sizeof(elf))
     goto bad;
   if(elf.magic != ELF_MAGIC)
     goto bad;

--- a/fs.c
+++ b/fs.c
@@ -53,7 +53,8 @@ bzero(int dev, int bno)
 static uint
 balloc(uint dev)
 {
-  int b, bi, m;
+  uint b;      // Block index as unsigned to match superblock fields
+  int bi, m;
   struct buf *bp;
   struct superblock sb;
 
@@ -146,7 +147,7 @@ static struct inode* iget(uint dev, uint inum);
 struct inode*
 ialloc(uint dev, short type)
 {
-  int inum;
+  uint inum;   // Inode number tracked as unsigned to align with sb.ninodes
   struct buf *bp;
   struct dinode *dip;
   struct superblock sb;
@@ -352,7 +353,8 @@ bmap(struct inode *ip, uint bn)
 static void
 itrunc(struct inode *ip)
 {
-  int i, j;
+  int i;
+  uint j;      // Use unsigned index to iterate over NINDIRECT entries
   struct buf *bp;
   uint *a;
 
@@ -496,7 +498,7 @@ dirlookup(struct inode *dp, char *name, uint *poff)
 int
 dirlink(struct inode *dp, char *name, uint inum)
 {
-  int off;
+  uint off;    // Offset within directory sized consistently with dp->size
   struct dirent de;
   struct inode *ip;
 

--- a/kbd.h
+++ b/kbd.h
@@ -33,19 +33,19 @@
 
 static uchar shiftcode[256] =
 {
-  [0x1D] CTL,
-  [0x2A] SHIFT,
-  [0x36] SHIFT,
-  [0x38] ALT,
-  [0x9D] CTL,
-  [0xB8] ALT
+  [0x1D] = CTL,
+  [0x2A] = SHIFT,
+  [0x36] = SHIFT,
+  [0x38] = ALT,
+  [0x9D] = CTL,
+  [0xB8] = ALT
 };
 
 static uchar togglecode[256] =
 {
-  [0x3A] CAPSLOCK,
-  [0x45] NUMLOCK,
-  [0x46] SCROLLLOCK
+  [0x3A] = CAPSLOCK,
+  [0x45] = NUMLOCK,
+  [0x46] = SCROLLLOCK
 };
 
 static uchar normalmap[256] =
@@ -61,13 +61,13 @@ static uchar normalmap[256] =
   NO,   NO,   NO,   NO,   NO,   NO,   NO,   '7',  // 0x40
   '8',  '9',  '-',  '4',  '5',  '6',  '+',  '1',
   '2',  '3',  '0',  '.',  NO,   NO,   NO,   NO,   // 0x50
-  [0x9C] '\n',      // KP_Enter
-  [0xB5] '/',       // KP_Div
-  [0xC8] KEY_UP,    [0xD0] KEY_DN,
-  [0xC9] KEY_PGUP,  [0xD1] KEY_PGDN,
-  [0xCB] KEY_LF,    [0xCD] KEY_RT,
-  [0x97] KEY_HOME,  [0xCF] KEY_END,
-  [0xD2] KEY_INS,   [0xD3] KEY_DEL
+  [0x9C] = '\n',      // KP_Enter
+  [0xB5] = '/',       // KP_Div
+  [0xC8] = KEY_UP,    [0xD0] = KEY_DN,
+  [0xC9] = KEY_PGUP,  [0xD1] = KEY_PGDN,
+  [0xCB] = KEY_LF,    [0xCD] = KEY_RT,
+  [0x97] = KEY_HOME,  [0xCF] = KEY_END,
+  [0xD2] = KEY_INS,   [0xD3] = KEY_DEL
 };
 
 static uchar shiftmap[256] =
@@ -83,13 +83,13 @@ static uchar shiftmap[256] =
   NO,   NO,   NO,   NO,   NO,   NO,   NO,   '7',  // 0x40
   '8',  '9',  '-',  '4',  '5',  '6',  '+',  '1',
   '2',  '3',  '0',  '.',  NO,   NO,   NO,   NO,   // 0x50
-  [0x9C] '\n',      // KP_Enter
-  [0xB5] '/',       // KP_Div
-  [0xC8] KEY_UP,    [0xD0] KEY_DN,
-  [0xC9] KEY_PGUP,  [0xD1] KEY_PGDN,
-  [0xCB] KEY_LF,    [0xCD] KEY_RT,
-  [0x97] KEY_HOME,  [0xCF] KEY_END,
-  [0xD2] KEY_INS,   [0xD3] KEY_DEL
+  [0x9C] = '\n',      // KP_Enter
+  [0xB5] = '/',       // KP_Div
+  [0xC8] = KEY_UP,    [0xD0] = KEY_DN,
+  [0xC9] = KEY_PGUP,  [0xD1] = KEY_PGDN,
+  [0xCB] = KEY_LF,    [0xCD] = KEY_RT,
+  [0x97] = KEY_HOME,  [0xCF] = KEY_END,
+  [0xD2] = KEY_INS,   [0xD3] = KEY_DEL
 };
 
 static uchar ctlmap[256] =
@@ -101,12 +101,12 @@ static uchar ctlmap[256] =
   C('D'),  C('F'),  C('G'),  C('H'),  C('J'),  C('K'),  C('L'),  NO,
   NO,      NO,      NO,      C('\\'), C('Z'),  C('X'),  C('C'),  C('V'),
   C('B'),  C('N'),  C('M'),  NO,      NO,      C('/'),  NO,      NO,
-  [0x9C] '\r',      // KP_Enter
-  [0xB5] C('/'),    // KP_Div
-  [0xC8] KEY_UP,    [0xD0] KEY_DN,
-  [0xC9] KEY_PGUP,  [0xD1] KEY_PGDN,
-  [0xCB] KEY_LF,    [0xCD] KEY_RT,
-  [0x97] KEY_HOME,  [0xCF] KEY_END,
-  [0xD2] KEY_INS,   [0xD3] KEY_DEL
+  [0x9C] = '\r',      // KP_Enter
+  [0xB5] = C('/'),    // KP_Div
+  [0xC8] = KEY_UP,    [0xD0] = KEY_DN,
+  [0xC9] = KEY_PGUP,  [0xD1] = KEY_PGDN,
+  [0xCB] = KEY_LF,    [0xCD] = KEY_RT,
+  [0x97] = KEY_HOME,  [0xCF] = KEY_END,
+  [0xD2] = KEY_INS,   [0xD3] = KEY_DEL
 };
 

--- a/lapic.c
+++ b/lapic.c
@@ -127,6 +127,8 @@ lapiceoi(void)
 void
 microdelay(int us)
 {
+  // Parameter is unused on this platform; cast suppresses warning under -Wextra.
+  (void)us;
 }
 
 #define IO_RTC  0x70

--- a/main.c
+++ b/main.c
@@ -104,7 +104,7 @@ bootothers(void)
     // its first instruction.
     stack = kalloc();
     *(void**)(code-4) = stack + KSTACKSIZE;
-    *(void**)(code-8) = mpmain;
+    *(void (**)(void))(code-8) = mpmain;  // Store entry point with explicit function pointer type
 
     lapicstartap(c->id, (uint)code);
 

--- a/proc.c
+++ b/proc.c
@@ -412,12 +412,12 @@ void
 procdump(void)
 {
   static char *states[] = {
-  [UNUSED]    "unused",
-  [EMBRYO]    "embryo",
-  [SLEEPING]  "sleep ",
-  [RUNNABLE]  "runble",
-  [RUNNING]   "run   ",
-  [ZOMBIE]    "zombie"
+  [UNUSED]   = "unused",
+  [EMBRYO]   = "embryo",
+  [SLEEPING] = "sleep ",
+  [RUNNABLE] = "runble",
+  [RUNNING]  = "run   ",
+  [ZOMBIE]   = "zombie"
   };
   int i;
   struct proc *p;

--- a/sh.c
+++ b/sh.c
@@ -72,6 +72,7 @@ runcmd(struct cmd *cmd)
   switch(cmd->type){
   default:
     panic("runcmd");
+    /* fallthrough */
 
   case EXEC:
     ecmd = (struct execcmd*)cmd;

--- a/stressfs.c
+++ b/stressfs.c
@@ -14,6 +14,8 @@
 int
 main(int argc, char *argv[])
 {
+  (void)argc;
+  (void)argv;
   int fd, i;
   char path[] = "stressfs0";
 

--- a/syscall.c
+++ b/syscall.c
@@ -100,28 +100,28 @@ extern int sys_uptime(void);
 extern int sys_ioctl(void);
 
 static int (*syscalls[])(void) = {
-[SYS_chdir]   sys_chdir,
-[SYS_close]   sys_close,
-[SYS_dup]     sys_dup,
-[SYS_exec]    sys_exec,
-[SYS_exit]    sys_exit,
-[SYS_fork]    sys_fork,
-[SYS_fstat]   sys_fstat,
-[SYS_getpid]  sys_getpid,
-[SYS_kill]    sys_kill,
-[SYS_link]    sys_link,
-[SYS_mkdir]   sys_mkdir,
-[SYS_mknod]   sys_mknod,
-[SYS_open]    sys_open,
-[SYS_pipe]    sys_pipe,
-[SYS_read]    sys_read,
-[SYS_sbrk]    sys_sbrk,
-[SYS_sleep]   sys_sleep,
-[SYS_unlink]  sys_unlink,
-[SYS_wait]    sys_wait,
-[SYS_write]   sys_write,
-[SYS_uptime]  sys_uptime,
-[SYS_ioctl]   sys_ioctl,
+[SYS_chdir]  = sys_chdir,
+[SYS_close]  = sys_close,
+[SYS_dup]    = sys_dup,
+[SYS_exec]   = sys_exec,
+[SYS_exit]   = sys_exit,
+[SYS_fork]   = sys_fork,
+[SYS_fstat]  = sys_fstat,
+[SYS_getpid] = sys_getpid,
+[SYS_kill]   = sys_kill,
+[SYS_link]   = sys_link,
+[SYS_mkdir]  = sys_mkdir,
+[SYS_mknod]  = sys_mknod,
+[SYS_open]   = sys_open,
+[SYS_pipe]   = sys_pipe,
+[SYS_read]   = sys_read,
+[SYS_sbrk]   = sys_sbrk,
+[SYS_sleep]  = sys_sleep,
+[SYS_unlink] = sys_unlink,
+[SYS_wait]   = sys_wait,
+[SYS_write]  = sys_write,
+[SYS_uptime] = sys_uptime,
+[SYS_ioctl]  = sys_ioctl,
 };
 
 void
@@ -130,7 +130,7 @@ syscall(void)
   int num;
   
   num = proc->tf->eax;
-  if(num >= 0 && num < NELEM(syscalls) && syscalls[num])
+  if(num >= 0 && (uint)num < NELEM(syscalls) && syscalls[num])
     proc->tf->eax = syscalls[num]();
   else {
     cprintf("%d %s: unknown sys call %d\n",

--- a/sysfile.c
+++ b/sysfile.c
@@ -148,10 +148,10 @@ bad:
 static int
 isdirempty(struct inode *dp)
 {
-  int off;
+  uint off;  // Offset within directory treated as unsigned to match size field
   struct dirent de;
 
-  for(off=2*sizeof(de); off<dp->size; off+=sizeof(de)){
+  for(off = 2*sizeof(de); off < dp->size; off += sizeof(de)){
     if(readi(dp, (char*)&de, off, sizeof(de)) != sizeof(de))
       panic("isdirempty: readi");
     if(de.inum != 0)
@@ -351,8 +351,8 @@ sys_exec(void)
     return -1;
   }
   memset(argv, 0, sizeof(argv));
-  for(i=0;; i++){
-    if(i >= NELEM(argv))
+  for(i = 0;; i++){
+    if((uint)i >= NELEM(argv))
       return -1;
     if(fetchint(proc, uargv+4*i, (int*)&uarg) < 0)
       return -1;

--- a/sysproc.c
+++ b/sysproc.c
@@ -64,7 +64,7 @@ sys_sleep(void)
     return -1;
   acquire(&tickslock);
   ticks0 = ticks;
-  while(ticks - ticks0 < n){
+  while(ticks - ticks0 < (uint)n){
     if(proc->killed){
       release(&tickslock);
       return -1;

--- a/usertests.c
+++ b/usertests.c
@@ -95,7 +95,7 @@ writetest1(void)
     exit();
   }
 
-  for(i = 0; i < MAXFILE; i++){
+  for(i = 0; (uint)i < MAXFILE; i++){
     ((int*)buf)[0] = i;
     if(write(fd, buf, 512) != 512){
       printf(stdout, "error: write big file failed\n", i);
@@ -236,7 +236,7 @@ pipe1(void)
       }
       total += n;
       cc = cc * 2;
-      if(cc > sizeof(buf))
+      if(cc > (int)sizeof(buf))
         cc = sizeof(buf);
     }
     if(total != 5 * 1033)
@@ -389,7 +389,7 @@ sharedfd(void)
   }
   nc = np = 0;
   while((n = read(fd, buf, sizeof(buf))) > 0){
-    for(i = 0; i < sizeof(buf); i++){
+    for(i = 0; i < (int)sizeof(buf); i++){
       if(buf[i] == 'c')
         nc++;
       if(buf[i] == 'p')
@@ -699,7 +699,7 @@ concreate(void)
       continue;
     if(de.name[0] == 'C' && de.name[2] == '\0'){
       i = de.name[1] - '0';
-      if(i < 0 || i >= sizeof(fa)){
+      if(i < 0 || (uint)i >= sizeof(fa)){
         printf(1, "concreate weird file %s\n", de.name);
         exit();
       }
@@ -1344,7 +1344,7 @@ sbrktest(void)
     printf(1, "pipe() failed\n");
     exit();
   }
-  for(i = 0; i < sizeof(pids)/sizeof(pids[0]); i++){
+  for(i = 0; i < (int)(sizeof(pids)/sizeof(pids[0])); i++){
     if((pids[i] = fork()) == 0){
       // allocate the full 640K
       sbrk((640 * 1024) - (uint)sbrk(0));
@@ -1358,7 +1358,7 @@ sbrktest(void)
   // if those failed allocations freed up the pages they did allocate,
   // we'll be able to allocate here
   c = sbrk(4096);
-  for(i = 0; i < sizeof(pids)/sizeof(pids[0]); i++){
+  for(i = 0; i < (int)(sizeof(pids)/sizeof(pids[0])); i++){
     if(pids[i] == -1)
       continue;
     kill(pids[i]);
@@ -1426,7 +1426,7 @@ bsstest(void)
   int i;
 
   printf(stdout, "bss test\n");
-  for(i = 0; i < sizeof(uninit); i++){
+  for(i = 0; i < (int)sizeof(uninit); i++){
     if(uninit[i] != '\0'){
       printf(stdout, "bss test failed\n");
       exit();
@@ -1462,6 +1462,8 @@ bigargtest(void)
 int
 main(int argc, char *argv[])
 {
+  (void)argc;
+  (void)argv;
   printf(1, "usertests starting\n");
 
   if(open("usertests.ran", 0) >= 0){

--- a/vm.c
+++ b/vm.c
@@ -79,9 +79,9 @@ mappages(pde_t *pgdir, void *la, uint size, uint pa, int perm)
 {
   char *a, *last;
   pte_t *pte;
-  
-  a = PGROUNDDOWN(la);
-  last = PGROUNDDOWN(la + size - 1);
+
+  a = PGROUNDDOWN((char*)la);
+  last = PGROUNDDOWN((char*)la + size - 1);
   for(;;){
     pte = walkpgdir(pgdir, a, 1);
     if(pte == 0)
@@ -142,7 +142,9 @@ setupkvm(void)
   memset(pgdir, 0, PGSIZE);
   k = kmap;
   for(k = kmap; k < &kmap[NELEM(kmap)]; k++)
-    if(mappages(pgdir, k->p, k->e - k->p, (uint)k->p, k->perm) < 0)
+    if(mappages(pgdir, k->p,
+                (uint)((char*)k->e - (char*)k->p),
+                (uint)k->p, k->perm) < 0)
       return 0;
 
   return pgdir;
@@ -217,7 +219,7 @@ loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset, uint sz)
       n = sz - i;
     else
       n = PGSIZE;
-    if(readi(ip, (char*)pa, offset+i, n) != n)
+    if(readi(ip, (char*)pa, offset+i, n) != (int)n)
       return -1;
   }
   return 0;


### PR DESCRIPTION
## Summary
- enforce rigorous warnings by adding `-Wextra -pedantic` to `CFLAGS`
- resolve numerous sign, initializer, and unused-parameter warnings across kernel, drivers, and user programs

## Testing
- `make`


------
https://chatgpt.com/codex/tasks/task_e_6892eb0176b08331851a2fab285628ee