### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: Continuous Integration
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install build toolchain
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential gcc-multilib clang clang-tidy make
+
+      - name: Build project
+        run: make
+
+      - name: Run clang-tidy
+        run: |
+          git ls-files '*.c' | xargs -n 1 clang-tidy -- -I.


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build xv6-network and run clang-tidy on pull requests

## Testing
- `make`
- `git ls-files '*.c' | xargs -n 1 clang-tidy -- -I.`

------
https://chatgpt.com/codex/tasks/task_e_6892eaf483488331893ba72a970d341a