### PR TITLE
Add MIT license and reference in documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 xv6-network contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README
+++ b/README
@@ -48,3 +48,7 @@ To run in QEMU, run "make qemu".
 
 To create a typeset version of the code, run "make xv6.pdf".  This
 requires the "mpage" utility.  See http://www.mesa.nl/pub/mpage/.
+
+LICENSE
+
+This project is licensed under the MIT License; see the LICENSE file for details.

--- a/README.textile
+++ b/README.textile
@@ -5,7 +5,7 @@ h2. Abstruct
 
 This project will be the implementation of a network in xv6. Supported NIC will be NE2000. This implement referes to MINIX.
 
-These source codes are licenced under the BSD license, which is the same as the licenses of xv6 and MINIX.
+These source codes are licensed under the MIT License. See the LICENSE file for details.
 
 h2. Change Log
 


### PR DESCRIPTION
## Summary
- add MIT `LICENSE`
- link to new license from `README` and `README.textile`

## Testing
- `make > /tmp/make.log && tail -n 20 /tmp/make.log`


------
https://chatgpt.com/codex/tasks/task_e_6892eaf154408331855dca96527319cc