### PR TITLE
Add build script with selectable profiles

### DIFF
--- a/README
+++ b/README
@@ -41,6 +41,17 @@ need to install a cross-compiler gcc suite capable of producing x86 ELF
 binaries.  See http://pdos.csail.mit.edu/6.828/2007/tools.html.
 Then run "make TOOLPREFIX=i386-jos-elf-".
 
+Alternatively, a convenience script `build.sh` provides curated
+optimization profiles and encapsulates common build steps. Example
+invocations are shown below:
+
+    ./build.sh --profile=developer   # debug-oriented build with symbols
+    ./build.sh --profile=performance # maximal optimizations for benchmarking
+    ./build.sh --profile=release     # production build with assertions removed
+
+The script cleans the tree before compilation and parallelizes the
+build using all available processors.
+
 To run xv6, you can use Bochs or QEMU, both PC simulators.
 Bochs makes debugging easier, but QEMU is much faster. 
 To run in Bochs, run "make bochs" and then type "c" at the bochs prompt.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+#
+# build.sh - Configurable build script for xv6-network
+#
+# This script acts as a thin wrapper around the repository's Makefile.
+# It exposes a user-friendly interface for selecting build profiles that
+# tune compilation flags for different development scenarios.
+#
+# Usage:
+#   ./build.sh --profile=<developer|performance|release>
+#
+# Profiles:
+#   developer   - Unoptimized build with maximal debug information and
+#                 debug-friendly defines. Suitable for day-to-day kernel
+#                 hacking and introspection under debuggers.
+#   performance - Aggressively optimized build aimed at benchmarking on
+#                 the local machine. Prioritizes speed over debuggability.
+#   release     - Production-style build with optimizations and assertions
+#                 disabled. Generates smaller binaries intended for
+#                 distribution or deployment.
+#
+# When invoked with no arguments or an unsupported profile, the script
+# prints this help text.
+
+set -euo pipefail
+
+# Display usage information and exit.
+usage() {
+	cat <<USAGE
+Usage: $0 --profile=developer|performance|release
+USAGE
+	exit 1
+}
+
+# Ensure a profile was supplied.
+[[ $# -eq 0 ]] && usage
+
+case "$1" in
+--profile=developer)
+	# Debugging build: disable optimizations, keep symbols, add DEBUG define
+	CFLAGS_PROFILE="-O0 -g3 -fno-omit-frame-pointer -DDEBUG"
+	;;
+--profile=performance)
+	# High-performance build: enable LTO and target local architecture
+	CFLAGS_PROFILE="-O3 -march=native -flto -fomit-frame-pointer"
+	;;
+--profile=release)
+	# Release build: moderate optimization, strip symbols, disable asserts
+	CFLAGS_PROFILE="-O2 -DNDEBUG -s"
+	;;
+*)
+	usage
+	;;
+esac
+
+# Always start from a clean tree to avoid stale objects with wrong flags.
+make clean >/dev/null
+
+# Invoke make with the chosen profile flags. We append to existing CFLAGS
+# from the Makefile to preserve essential options like -m32 and -Wall.
+make -j"$(nproc)" "CFLAGS+=${CFLAGS_PROFILE}"


### PR DESCRIPTION
## Summary
- introduce `build.sh` script with developer, performance, and release profiles
- document new build script usage in README

## Testing
- `shfmt -w build.sh`
- `shellcheck build.sh`
- `./build.sh`
- `./build.sh --profile=developer` (fails: ld: i386:x86-64 architecture of input file `bootasm.o` is incompatible with i386 output)

------
https://chatgpt.com/codex/tasks/task_e_6892eb0789d48331ae9cc6cf269944ba

## Summary by Sourcery

Add a build.sh wrapper script with selectable developer, performance, and release profiles for xv6-network builds and update the README with its usage

New Features:
- Add build.sh script for wrapping the Makefile with configurable build profiles

Build:
- Introduce developer, performance, and release profiles to tune CFLAGS and automate clean builds

Documentation:
- Document build.sh usage and available profiles in the README