### PR TITLE
docs: translate NE driver comments

### DIFF
--- a/eth/eth.h
+++ b/eth/eth.h
@@ -1,5 +1,5 @@
 
-// IPCをセットアップする。IPCの仕様次第なので、実装はまだできない。
+// Prepare IPC; actual implementation depends on the IPC specification.
 #define ETH_IPC_SETUP     1
 
 


### PR DESCRIPTION
## Summary
- replace Japanese comments in NE2000 driver and headers with English descriptions of DP8390 hardware behavior
- document NIC probing, PROM initialization, DMA operations, and buffer layout
- note IPC setup constant for future Ethernet work

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_6892eabf8a2c8331b64015d292ce64c3